### PR TITLE
Use BIRD as BGP feeder

### DIFF
--- a/base.py
+++ b/base.py
@@ -154,16 +154,19 @@ class Container(object):
 
             # get the interface used by the first IP address already added by Docker
             dev = None
+            pxlen = None
             res = self.local('ip addr').decode("utf-8")
 
             for line in res.split('\n'):
                 if ipv4_addresses[0] in line:
                     dev = line.split(' ')[-1].strip()
+                    pxlen = line.split('/')[1].split(' ')[0].strip()
             if not dev:
                 dev = "eth0"
+                pxlen = 8
 
             for ip in ipv4_addresses[1:]:
-                self.local('ip addr add {} dev {}'.format(ip, dev))
+                self.local(f'ip addr add {ip}/{pxlen} dev {dev}')
 
         return ctn
 

--- a/bgperf.py
+++ b/bgperf.py
@@ -42,7 +42,7 @@ from frr import FRRouting, FRRoutingTarget
 from frr_compiled import FRRoutingCompiled, FRRoutingCompiledTarget
 from rustybgp import RustyBGP, RustyBGPTarget
 from openbgp import OpenBGP, OpenBGPTarget
-from tester import ExaBGPTester
+from tester import ExaBGPTester, BIRDTester
 from mrt_tester import GoBGPMRTTester, ExaBGPMrtTester
 from bgpdump2 import Bgpdump2, Bgpdump2Tester
 from monitor import Monitor
@@ -149,8 +149,9 @@ def remove_old_containers():
     for ctn_name in get_ctn_names():
         if ctn_name.startswith(ExaBGPTester.CONTAINER_NAME_PREFIX) or \
             ctn_name.startswith(ExaBGPMrtTester.CONTAINER_NAME_PREFIX) or \
-            ctn_name.startswith(GoBGPMRTTester.CONTAINER_NAME_PREFIX) or\
-            ctn_name.startswith(Bgpdump2Tester.CONTAINER_NAME_PREFIX):
+            ctn_name.startswith(GoBGPMRTTester.CONTAINER_NAME_PREFIX) or \
+            ctn_name.startswith(Bgpdump2Tester.CONTAINER_NAME_PREFIX) or \
+            ctn_name.startswith(BIRDTester.CONTAINER_NAME_PREFIX):
             print('removing tester container', ctn_name)
             dckr.remove_container(ctn_name, force=True)
 
@@ -265,6 +266,8 @@ def bench(args):
                 tester_type = tester['type']
             if tester_type == 'normal':
                 tester_class = ExaBGPTester
+            elif tester_type == 'bird':
+                tester_class = BIRDTester
             elif tester_type == 'mrt':
                 if 'mrt_injector' not in tester:
                     mrt_injector = 'gobgp'
@@ -794,7 +797,7 @@ def gen_conf(args):
     if not mrt_injector:
         conf['testers'] = [{
             'name': 'tester',
-            'type': 'normal',
+            'type': 'bird',
             'neighbors': neighbors,
         }]
     else:

--- a/bird.py
+++ b/bird.py
@@ -21,8 +21,8 @@ class BIRD(Container):
     CONTAINER_NAME = None
     GUEST_DIR = '/root/config'
 
-    def __init__(self, host_dir, conf, image='bgperf/bird'):
-        super(BIRD, self).__init__(self.CONTAINER_NAME, image, host_dir, self.GUEST_DIR, conf)
+    def __init__(self, host_dir, conf, image='bgperf/bird', name=None):
+        super(BIRD, self).__init__(name if name is not None else self.CONTAINER_NAME, image, host_dir, self.GUEST_DIR, conf)
 
     @classmethod
     def build_image(cls, force=False, tag='bgperf/bird', checkout='HEAD', nocache=False):
@@ -30,7 +30,7 @@ class BIRD(Container):
 FROM ubuntu:latest
 WORKDIR /root
 RUN apt-get update && apt-get install -qy git autoconf libtool gawk make \
-flex bison libncurses-dev libreadline6-dev
+flex bison libncurses-dev libreadline6-dev iproute2
 RUN apt-get install -qy flex
 RUN git clone https://gitlab.labs.nic.cz/labs/bird.git bird
 RUN cd bird && git checkout {0} && autoreconf -i && ./configure && make && make install

--- a/tester.py
+++ b/tester.py
@@ -15,6 +15,7 @@
 
 from base import Tester
 from exabgp import ExaBGP
+from bird import BIRD
 import os
 from  settings import dckr
 
@@ -56,3 +57,50 @@ exabgp.daemon.daemonize=true \
 exabgp.daemon.user=root \
 exabgp {0}/{1}.conf'''.format(self.guest_dir, p['router-id']))
         return '\n'.join(startup)
+
+
+class BIRDTester(Tester, BIRD):
+
+    CONTAINER_NAME_PREFIX = 'bgperf_bird_tester_'
+
+    def __init__(self, name, host_dir, conf, image='bgperf/bird'):
+        super(BIRDTester, self).__init__('bgperf_bird_' + name, host_dir, conf, image)
+
+    def configure_neighbors(self, target_conf):
+        peers = list(self.conf.get('neighbors', {}).values())
+
+        for p in peers:
+            with open('{0}/{1}.conf'.format(self.host_dir, p['router-id']), 'w') as f:
+                local_address = p['local-address']
+                config = '''log "{5}/{2}.log" all;
+#debug protocols all;
+router id {2};
+protocol device {{}}
+protocol bgp {{
+source address {3};
+connect delay time 1;
+interface "eth0";
+strict bind;
+ipv4 {{ import none; export all; }};
+local {3} as {4};
+neighbor {0} as {1};
+}}
+protocol static {{ ipv4;
+'''.format(target_conf['local-address'], target_conf['as'],
+               p['router-id'], local_address, p['as'], self.guest_dir)
+                f.write(config)
+                for path in p['paths']:
+                    f.write('      route {0} via {1};\n'.format(path, local_address))
+                f.write('}')
+
+    def get_startup_cmd(self):
+        startup = [f'''#!/bin/bash
+ulimit -n 65536
+#sleep 2
+#(ip link; ip addr) > {self.guest_dir}/ip-a.log
+''']
+        peers = list(self.conf.get('neighbors', {}).values())
+        for p in peers:
+            startup.append('''bird -c {0}/{1}.conf -s {0}/{1}.ctl >>{0}/{1}.log 2>&1\n'''.format(self.guest_dir, p['router-id']))
+        return '\n'.join(startup)
+


### PR DESCRIPTION
Hello!

ExaBGP is slow and memory-bloated. This commit uses BIRD instead to feed routes to the target, enabling more accurate measurements and higher loads.

Maria