### PR TITLE
bump up rust version for rustybgp

### DIFF
--- a/rustybgp.py
+++ b/rustybgp.py
@@ -16,7 +16,7 @@ class RustyBGP(Container):
 
         cls.dockerfile = '''
 
-FROM rust:1.54-bullseye AS rust_builder
+FROM rust:1.56-bullseye AS rust_builder
 RUN rustup component add rustfmt
 RUN git clone https://github.com/osrg/rustybgp.git
 RUN cd rustybgp && cargo build --release && cp target/release/rustybgpd /root


### PR DESCRIPTION
The latest rustybgp needs rust 1.56.

Signed-off-by: FUJITA Tomonori <fujita.tomonori@gmail.com>