### PR TITLE
fix get_neighbors_state for rustybgp and gobgp with filter tests

### DIFF
--- a/gobgp.py
+++ b/gobgp.py
@@ -153,7 +153,14 @@ class GoBGPTarget(GoBGP, Target):
         for neighbor in neighbor_received_output:
             if 'afi_safis' in neighbor and 'accepted' in neighbor['afi_safis'][0]['state']:
                 neighbors_accepted[neighbor['state']['neighbor_address']] = neighbor['afi_safis'][0]['state']['accepted']
+            else:
+                neighbors_accepted[neighbor['state']['neighbor_address']] = 0
+
+            if 'afi_safis' in neighbor and 'received' in neighbor['afi_safis'][0]['state']:
                 neighbors_received[neighbor['state']['neighbor_address']] = neighbor['afi_safis'][0]['state']['received']
+            else:
+                neighbors_received[neighbor['state']['neighbor_address']] = 0
+
         return neighbors_received, neighbors_accepted
 
 ## Caveats


### PR DESCRIPTION
If a peer drops all the received routes, "/root/gobgp neighbor -j"
doesn't return 'accepted' key. So bgperf.py wrongly assumes that the
peer doesn't receive any routes. The benchmark never finishes.